### PR TITLE
Router setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+### Project:
+
+/data/
+
+### Python:
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ ifeq ($(only),all)
 	-f docker/daemon/Dockerfile \
 	--build-arg BUILD_DATE="$(shell date --rfc-3339 seconds)" \
 	-t netem-daemon:$(tag) .
+
+	docker build \
+	-f docker/router/Dockerfile \
+	--build-arg BUILD_DATE="$(shell date --rfc-3339 seconds)" \
+	-t netem-router:$(tag) .
 else
 	docker build \
 	-f docker/$(only)/Dockerfile \
@@ -60,6 +65,7 @@ clean: stop
 	docker rmi netem-controller
 	docker rmi netem-client
 	docker rmi netem-daemon
+	docker rmi netem-router
 
 .PHONY: exec
 service ?= daemon
@@ -79,8 +85,9 @@ sh:
 	netem-daemon sh
 
 .PHONY: interrupt
+name ?= netem_daemon_1
 interrupt:
-# Send a SIGINT signal to a container
+# Send a SIGINT signal to a container, defaulting to the daemon.
 	docker kill --signal SIGINT $(name)
 
 .PHONY: delay

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: start run up
 d ?= 
-start run up: down
+start run up:# down
 # Start up all of the containers defined in our docker compose yaml. If Linux is
 # being used then the linux override will be applied so that the traffic control
 # is able to work!

--- a/README.md
+++ b/README.md
@@ -3,12 +3,61 @@
 Generate network communication data for target tasks in diverse network conditions.
 
 **Table of contents**
+- [What does it do](#what-does-it-do)
+- [How to use](#how-to-use)
 - [Approach](#approach)
 - [Requirements](#requirements)
 - [Example](#example)
 - [Software / References](#software--references)
 
 **Note:** This is currently being developed primarily on **Windows 10** and **Linux**. If you are on Windows 10 you *must* use the **Hyper-V backend** for Docker. The WSL2 backend doesn't seem to work. This runs on Linux by using a docker-compose override which is added automatically. Mac is a mystery at the moment since my old Mac is incapable of running Docker (!), but theoretically Mac should work the same as Windows.
+
+## What does it do
+
+TODO
+
+## How to use
+
+1. Clone this repository with the submodule
+   ```
+   git clone --recurse-submodules
+   ```
+   then navigate to this directory.
+
+2. Build the Docker images
+   ```
+   make build
+   ```
+
+3. Specify target conditions and behaviors
+
+   TODO. Modify the `docker/docker-compose.yml` file.
+
+4. Run the tool, deploying all containers specified in the Compose file
+   ```
+   make run
+   ```
+
+5. Interrupt the tool
+   
+   The first step of gracefully stopping this tool is to send an interrupt signal to the daemon.
+   ```
+   docker kill -s SIGINT netem_daemon_1
+   ```
+
+   The daemon will catch the interrupt and tear down all containers. Collected data will be present in `data/`.
+
+6. Finish with the tool completely
+   
+   Once you are completely done with the tool, you can ensure all aspects of the tool are stopped.
+   ```
+   make stop
+   ```
+   And you can remove the built Docker images from your machine with
+   ```
+   make clean
+   ```
+   (you will need to rebuild the images if you choose to run this)
 
 ## Approach
 
@@ -24,7 +73,9 @@ Generate network communication data for target tasks in diverse network conditio
 
 ## Requirements
 
-This project requires [**Docker 19.03+**](https://docs.docker.com/get-docker/) and [**Docker Compose 1.27+**](https://docs.docker.com/compose/install/) (on Windows and Mac this is included with your installation of Docker Desktop) in order to run.
+This project runs on Linux, Mac, and Windows Pro or Education (Hyper-V must be available).
+
+You will need [**Docker 19.03+**](https://docs.docker.com/get-docker/) and [**Docker Compose 1.27+**](https://docs.docker.com/compose/install/) (on Windows and Mac this is included with your installation of Docker Desktop) in order to run.
 
 Finally, [**GNU Make**](https://www.gnu.org/software/make/) is used to make running specific tasks easier (by just running `make <target>` rather than running a `docker` or `docker-compose` command directly). If you're on Windows I recommend using **GitBash** as your main terminal, and referencing [this link](https://stackoverflow.com/questions/32127524/how-to-install-and-use-make-in-windows) for installing make. If you're on Mac you can use homebrew to `brew install make`.
 

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,5 +1,14 @@
 FROM python:3.8
 
+# Additional/nice-to-have software:
+#
+# - git for cloning in source code
+# - iproute2 for network emulation ability
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    iproute2
+
 # Install apt dependencies for running network-stats
 RUN apt-get update && \
     apt-get install -y \
@@ -9,6 +18,8 @@ RUN apt-get update && \
 RUN pip install \
     impacket \
     pcapy
+
+RUN git clone https://github.com/viasat/network-stats
 
 # Install apt dependencies for web browsing
 RUN apt-get update && \
@@ -30,20 +41,13 @@ RUN curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
 RUN pip install \
     selenium
 
-# #* VPN-RELATED SOFTWARE
-# RUN apt-get install -y openconnect openvpn net-tools && \
-#     curl -O https://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script
+#* VPN-RELATED SOFTWARE
+RUN apt-get install -y openconnect && \
+    curl -O https://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script
 
-# Additional/nice-to-have software:
-#
-# - git for cloning in source code
-# - iproute2 for network emulation ability
-RUN apt-get install -y \
-    git \
-    iproute2
-
-RUN git clone https://github.com/viasat/network-stats
-
+# ADD scripts/init/client.sh /
+# RUN chmod +x /client.sh
+# ENTRYPOINT ["/client.sh"]
 CMD ["sleep", "infinity"]
 
 # Metadata

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -15,9 +15,25 @@ RUN pip install \
     impacket \
     pcapy
 
-# Will probably add browsing related software here
+# Install apt dependencies for web browsing
+RUN apt-get update && \
+    apt-get install -y \
+    firefox-esr
+
+# We'll need geckodriver in order to use selenium
 #
-# RUN ...
+# Here we're just finding the download url to the latest pre-compiled release
+# for linux64, then downloading and extracting to a location that's part of PATH
+RUN curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
+    | grep browser_download_url \
+    | grep 'linux64.tar.gz"' \
+    | cut -d '"' -f 4 \
+    | wget -i - -O /dev/stdout \
+    | tar -xz -C /usr/local/bin/
+
+# Install python dependencies for automated web browsing
+RUN pip install \
+    selenium
 
 # #* VPN-RELATED SOFTWARE
 # RUN apt-get install -y openconnect openvpn net-tools && \

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,10 +1,5 @@
 FROM python:3.8
 
-# Metadata
-ARG BUILD_DATE
-LABEL maintainer="pgaddiso@ucsd.edu"
-LABEL org.opencontainers.image.created=${BUILD_DATE}
-
 # Install apt dependencies for running network-stats
 RUN apt-get update && \
     apt-get install -y \
@@ -49,4 +44,9 @@ RUN apt-get install -y \
 
 RUN git clone https://github.com/viasat/network-stats
 
-CMD sleep infinity
+CMD ["sleep", "infinity"]
+
+# Metadata
+ARG BUILD_DATE
+LABEL maintainer="pgaddiso@ucsd.edu"
+LABEL org.opencontainers.image.created=${BUILD_DATE}

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest
 
+# the iproute2 package lets us use `tc` for network emulation
+RUN apk add --update iproute2
+
+CMD ["sleep", "infinity"]
+
 # Metadata
 ARG BUILD_DATE
 LABEL maintainer="pgaddiso@ucsd.edu"
 LABEL org.opencontainers.image.created=${BUILD_DATE}
-
-# the iproute2 package lets us use `tc` for network emulation
-RUN apk add --update iproute2
-
-CMD sleep infinity

--- a/docker/daemon/Dockerfile
+++ b/docker/daemon/Dockerfile
@@ -1,14 +1,14 @@
 # FROM alpine:latest
 FROM python:3.8-alpine
 
-# Metadata
-ARG BUILD_DATE
-LABEL maintainer="pgaddiso@ucsd.edu"
-LABEL org.opencontainers.image.created=${BUILD_DATE}
-
 # The main purpose of this daemon is to launch containers connected to the
 # network of other containers in order to alter their network conditions.
 RUN apk add docker
 RUN pip install docker
 
-CMD sleep infinity
+CMD ["sleep", "infinity"]
+
+# Metadata
+ARG BUILD_DATE
+LABEL maintainer="pgaddiso@ucsd.edu"
+LABEL org.opencontainers.image.created=${BUILD_DATE}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,19 +45,19 @@ services:
   #   deploy:
   #     replicas: 1
   
-  # Runs a client script
-  scripter:
-    depends_on:
-      - daemon
-    image: netem-client
-    labels:
-      com.netem.behavior: script
-    volumes:
-      - ../scripts/:/scripts/
-      - ../network-stats/:/network-stats/
-      - ../data/:/data/
-    deploy:
-      replicas: 1
+  # # Runs a client script
+  # scripter:
+  #   depends_on:
+  #     - daemon
+  #   image: netem-client
+  #   labels:
+  #     com.netem.behavior: script
+  #   volumes:
+  #     - ../scripts/:/scripts/
+  #     - ../network-stats/:/network-stats/
+  #     - ../data/:/data/
+  #   deploy:
+  #     replicas: 1
 
   # # No command given -- should also sleep but raise warning.
   # nothing:
@@ -68,18 +68,51 @@ services:
   #   deploy:
   #     replicas: 1
 
+  client:
+    depends_on:
+      - daemon
+      - router
+    image: netem-client
+    networks:
+      intranet:
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - ../scripts/:/scripts/
+      - ../network-stats/:/network-stats/
+      - ../data/:/data/
+    labels:
+      com.netem.type: client
+      com.netem.behavior: ping
+
+  router:
+    depends_on:
+      - daemon
+    image: netem-router
+    networks:
+      default:
+        priority: 1000 # Ensure we use the eth0 interface
+      intranet:
+        aliases:
+          - router
+    cap_add:
+      - NET_ADMIN
+    labels:
+      com.netem.type: router
+      com.netem.tc.delay: 100ms
+
   daemon:
     image: netem-daemon
     command: python /scripts/daemon.py
     environment:
-      # This host address should work for Windows and Mac.
+      # This host address should work for Windows and Mac. For Linux a different
+      # approach is needed in order to allow Docker within Docker -- see the
+      # override file.
       DOCKER_HOST: tcp://host.docker.internal:2375
-      # Whereas this host should work on Linux
-      # DOCKER_HOST: tcp://172.17.0.1:2375
     volumes:
       - ../scripts/:/scripts/
+    labels:
+      com.netem.type: daemon
 
 networks:
-  default:
-    name: netem
-    driver: bridge
+  intranet:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,9 +53,9 @@ services:
     labels:
       com.netem.behavior: script
     volumes:
-      - type: bind
-        source: ../scripts/
-        target: /scripts/
+      - ../scripts/:/scripts/
+      - ../network-stats/:/network-stats/
+      - ../data/:/data/
     deploy:
       replicas: 1
 
@@ -77,9 +77,7 @@ services:
       # Whereas this host should work on Linux
       # DOCKER_HOST: tcp://172.17.0.1:2375
     volumes:
-      - type: bind
-        source: ../scripts/
-        target: /scripts/
+      - ../scripts/:/scripts/
 
 networks:
   default:

--- a/docker/router/Dockerfile
+++ b/docker/router/Dockerfile
@@ -1,0 +1,24 @@
+# Router
+# ======
+#
+# The router serves as the connection between the client containers and the
+# external internet. We'll run network emulation inside of the router (iproute2)
+# and the router needs to be able to re-route packets (iptables).
+#
+# This must be run with cap-add NET_ADMIN or neither iptables nor tc will be
+# permitted.
+# 
+
+FROM alpine:latest
+
+RUN apk add --update iproute2 iptables
+
+# ADD scripts/init/router.sh /
+# RUN chmod +x /router.sh
+# ENTRYPOINT ["/router.sh"]
+CMD ["sleep", "infinity"]
+
+# Metadata
+ARG BUILD_DATE
+LABEL maintainer="pgaddiso@ucsd.edu"
+LABEL org.opencontainers.image.created=${BUILD_DATE}

--- a/scripts/client/collection.py
+++ b/scripts/client/collection.py
@@ -1,1 +1,22 @@
 # Run network-stats and save the data
+import datetime
+import os
+import pathlib
+from pathlib import Path
+
+# TODO: Eventually add naming convention for network conditions and behavior...
+# or maybe just embed metadata as frontmatter, like a csvy file.
+container_id = (
+    os.popen("cat /proc/self/cgroup | head -1 | tr '/' '\n' | tail -1")
+    .read()
+    .strip()
+)
+
+date = datetime.date.today().isoformat()
+
+filename = f"{date}_{container_id}.csv"
+
+datadir = "/data/"
+
+# For now, just call network-stats and send the output to the data mount.
+os.system(f'network-stats/network_stats.py -i eth0 -e {Path(datadir, filename)}')

--- a/scripts/client/collection.py
+++ b/scripts/client/collection.py
@@ -6,15 +6,15 @@ from pathlib import Path
 
 # TODO: Eventually add naming convention for network conditions and behavior...
 # or maybe just embed metadata as frontmatter, like a csvy file.
+
+# This is just to find the container ID for the filename.
 container_id = (
     os.popen("cat /proc/self/cgroup | head -1 | tr '/' '\n' | tail -1")
     .read()
     .strip()
 )
-
-date = datetime.date.today().isoformat()
-
-filename = f"{date}_{container_id}.csv"
+timestamp = datetime.datetime.now().strftime('%Y%m%dT%H%M%S')
+filename = f"{timestamp}_{container_id}.csv"
 
 datadir = "/data/"
 

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -89,8 +89,9 @@ def set_up_client(event):
 
     ## Network-stats collection
 
-    # TODO: Add data directory mount to save results; Run network-stats!
-    # client.exec_run(network_stats_command, detach=True)
+    network_stats_command = 'python scripts/client/collection.py'
+
+    client.exec_run(network_stats_command, detach=True)
 
 # TODO: Implement timeout.
 # 

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -205,6 +205,7 @@ def listen_for_interrupt(handler, timeout=None):
     """
 
     logging.info('Listening for daemon interrupt.')
+    logging.warning('Please run `docker kill -s SIGINT netem_daemon_1` to stop this service. Failure to do so will result in data loss.')
 
     # TODO: If a timeout has been specified, halt after that amount of time
 

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -1,8 +1,33 @@
+# Daemon
+# ======
+#
+# The daemon is responsible for issuing commands to all other containers. As
+# such, the daemon is essentially just funning a bunch of docker exec's.
+#
+# The daemon is created before all other containers, so it starts to listen for
+# container startup events in order to set up the following clients and routers.
+#
+# When a router starts up, the daemon will examine its labels and exec a network
+# emulation command in the router based on those labels.
+#
+# When a container starts up, the daemon will examine its labels and exec
+# commands to establish a vpn connection, run automated browsing, and collect
+# network-stats -- again some of which (namely the behavior of the automated
+# browsing) is determined by the labels.
+#
+# After a little bit of time, the daemon will stop listening to docker startup
+# events and start listening for an interrupt signal. When received, the daemon
+# will teardown all clients and routers gracefully by interrupting all processes
+# and waiting until the interrupts are complete before shutting down the
+# containers. Then the daemon will exit itself.
+#
+
 import asyncio
 import docker
 import time
 import logging
 import signal
+import sys
 
 # Docker logs only show stdout of PID 1 -- so we'll write directly to that!
 logger = logging.basicConfig(
@@ -13,18 +38,79 @@ logger = logging.basicConfig(
     level=logging.INFO
 )
 
+# Establish a global uncaught exception handler to log the exception
+def log_exception(exc_type, exc_value, exc_traceback):
+    logging.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+
+sys.excepthook = log_exception
+
 def redirect_to_out(command):
     """
     Reformats a command for docker exec so that the command output is redirected
     to the stdout of PID 1 (in order to show up in the docker log).
     """
     return f'sh -c "{command} >> /proc/1/fd/1"'
+    # return f'{command} >> /proc/1/fd/1'
 
 PROJECT_NAME = 'netem'
 LABEL_PREFIX = 'com.netem.'
 
 # The DOCKER_HOST environment variable should already be defined
 API = docker.from_env()
+
+def setup_router(router):
+    
+    logging.info(f'[+] Setting up router `{router.name}`')
+
+    ## Networking configuration
+
+    # Re-route packets within the network.
+    reroute_command = 'iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE'
+
+    router.exec_run(
+        reroute_command
+    )
+
+    logging.info(f'Packet rerouting for `{router.name}` complete.')
+
+    ## Network emulation
+
+    # Start by getting all traffic control labels. These are rules that we will
+    # directly use to emulate conditions.
+    #
+    # We end up with a mapping of tc rules to their arguments.
+    # e.g. {"delay": "100ms 20ms distribution normal"}
+    #
+    # /\/\/\/\/\/\/\/\
+    #! TODO: This does *not* work for bandwidth -- which is very important.
+    # Critical that we fix this and add bandwidth support.
+    #
+    # Basically: THIS NEEDS TO BE REWORKED.
+    #
+    # See notes on "Netem bandwidth limiting" for the proper commands.
+    # \/\/\/\/\/\/\/\/
+    
+    rule_names = [label for label in router.labels if label.startswith(LABEL_PREFIX+'tc')]
+    rules = {
+        name.split('.')[-1]: router.labels.get(name)
+        for name in rule_names
+    }
+
+    # tc will take in all rules and arguments as simply space separated.
+    rule_string = ' '.join([f"{k} {v}" for k,v in rules.items()])
+    tc_command = f"tc qdisc add dev eth0 root netem {rule_string}"
+
+    router.exec_run(
+        tc_command
+    )
+
+    logging.info(f'Network emulation for `{router.name}` complete.')
+
+def teardown_router(router):
+
+    logging.info(f'[-] Tearing down `{router.name}`.')
+    router.stop()
+    logging.info(f'`{router.name}` stopped.')
 
 # We'll do the setup for each container as it is created. To do this, we'll
 # listen for docker 'start' events, and use a callback.
@@ -36,35 +122,20 @@ def setup_client(client):
     3. Network-stats collection
     """
 
-    logging.info(f"Setting up `{client.name}`")
+    logging.info(f"[+] Setting up client `{client.name}`")
 
-    ## Network emulation
+    ## Connect to router
 
-    # Start by getting all traffic control labels. These are rules that we will
-    # directly use to emulate conditions.
+    # Connect to the internet *through* the router container. Note that the
+    # router container should always have the hostname alias `router` on the
+    # shared network, so we can just find the ip of that hostname.
     #
-    # We end up with a mapping of tc rules to their arguments.
-    # e.g. {"delay": "100ms 20ms distribution normal"}
-    rule_names = [label for label in client.labels if label.startswith(LABEL_PREFIX+'tc')]
-    rules = {
-        name.split('.')[-1]: client.labels.get(name)
-        for name in rule_names
-    }
-
-    # tc will take in all rules and arguments as simply space separated.
-    rule_string = ' '.join([f"{k} {v}" for k,v in rules.items()])
-    tc_command = f"tc qdisc add dev eth0 root netem {rule_string}"
-
-    # Now we need to create a traffic controller container connected to this
-    # container's network in order to run the command
-    API.containers.run(
-        image="netem-controller",
-        cap_add="NET_ADMIN", network=f"container:{client.name}",
-        command=tc_command,
-        detach=True
+    # To support subshells $() we need to run this with sh -c.
+    client.exec_run(
+        ['sh', '-c', "ip route replace default via $(getent hosts router | cut -d ' ' -f 1)"]
     )
 
-    logging.info(f'Network emulation for `{client.name}` complete.')
+    logging.info(f'Client `{client.name}` connected to internal router.')
 
     ## Behavior launching
 
@@ -111,7 +182,7 @@ def teardown_client(client):
     3. Stop container
     """
 
-    logging.info(f'Tearing down `{client.name}`.')
+    logging.info(f'[-] Tearing down `{client.name}`.')
 
     # Interrupt all processes except for the main sleep. It is important that
     # we interrupt rather than kill, otherwise the network-stats data will not
@@ -127,17 +198,10 @@ def teardown_client(client):
     client.stop()
     logging.info(f'`{client.name}` stopped.')
 
-    # # Interrupt the collection script and behavior script with SIGINT. We'll
-    # # first need to find the PIDs running these scripts.
-    # pattern = lambda script: f"'python .*/{script}\.py$'"
-    # client.exec_run(f"pkill -f {pattern('collection')}")
-    # client.exec_run(f"pkill -f network-stats")
-    # client.exec_run(f"pkill -f {pattern('behavior')}")
-
 # The daemon doesn't need to wait forever for setup. Also, after setup is
 # complete, the containers should run for a set amount of time then be
 # interrupted and cleaned up.
-def listen_for_client_startup(timeout=15):
+def listen_for_container_startup(timeout=15):
     """
 
     Returns a list of clients that have been set up.
@@ -152,6 +216,7 @@ def listen_for_client_startup(timeout=15):
 
     logging.info(f'Listening for docker startup events. Will stop listening after {timeout} seconds.')
 
+    routers = []
     clients = []
 
     # Listen to docker events and handle client container setup when they start.
@@ -168,27 +233,42 @@ def listen_for_client_startup(timeout=15):
                 decode=True
             ):
             labels = event['Actor']['Attributes']
-            is_daemon = labels.get('com.docker.compose.service') == 'daemon'
-            if not is_daemon:
+
+            container_type = labels.get('com.netem.type')
+
+            if container_type == 'router':
+                router = API.containers.get(event['id'])
+                routers.append(router)
+                setup_router(router)
+            elif container_type == 'client':
                 client = API.containers.get(event['id'])
                 clients.append(client)
                 setup_client(client)
+            elif container_type == 'daemon':
+                pass
+            else:
+                logging.warning(f'Unknown container type `{container_type}` seen for {labels.get("com.docker.compose.service")}. Ignoring.')
 
     except TimeoutError:
         logging.info('Timeout seen.')
 
     finally:
         logging.info('No longer listening for docker events.')
-        return clients
+        return routers, clients
 
-def handle_interrupt(clients):
+def handle_interrupt(routers, clients):
 
     logging.info('Daemon interrupted!')
 
     for client in clients:
         teardown_client(client)
 
-    logging.info('All clients stopped, Daemon will now exit.')
+    logging.info('All clients stopped.')
+
+    for router in routers:
+        teardown_router(router)
+
+    logging.info('All container stopped, Daemon will now exit.')
     logging.info('Check `/data` for the network-stats output. Thanks for using this tool!')
     exit(0)
 
@@ -205,7 +285,11 @@ def listen_for_interrupt(handler, timeout=None):
     """
 
     logging.info('Listening for daemon interrupt.')
-    logging.warning('Please run `docker kill -s SIGINT netem_daemon_1` to stop this service. Failure to do so will result in data loss.')
+    logging.warning('\n\
+========\n\
+Please run `make interrupt` or `docker kill -s SIGINT netem_daemon_1` to stop\n\
+this tool. Failure to do so will result in data loss.\n\
+========')
 
     # TODO: If a timeout has been specified, halt after that amount of time
 
@@ -214,8 +298,9 @@ def listen_for_interrupt(handler, timeout=None):
 
 if __name__ == "__main__":
 
-    clients = listen_for_client_startup(timeout=8)
-    listen_for_interrupt(handler=lambda: handle_interrupt(clients))
+    routers, clients = listen_for_container_startup(timeout=8)
+
+    listen_for_interrupt(handler=lambda: handle_interrupt(routers, clients))
     
     # While we're waiting for some signal the daemon can just chill out!
     signal.pause()


### PR DESCRIPTION
Three features (branches `headless-browsing`, `collect-network-stats`, and `router-setup`) are included in this pull request. The main changes:

1. Add headless browsing and Selenium to client image. 
2. Add daemon code and Compose setup that lets the client run arbitrary python scripts (e.g. Selenium scripts, network-stats)
3. Add daemon code for gracefully stopping the clients by sending an interrupt signal rather than just terminating all processes. This prevents data loss, as network-stats only writes to its file after being interrupted.
4. Change general structure of the containers in the Compose setup and in the daemon code such that we now have a container acting as a router for one or many clients which connect to the same internal network.

I recommend looking at the diffs of each commit. The diff view coupled with the commit messages themselves should provide a reasonably good idea of what specifically changed.