### PR TITLE
Make clients log in to the vpn during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,31 @@ TODO
 
    TODO. Modify the `docker/docker-compose.yml` file.
 
-4. Run the tool, deploying all containers specified in the Compose file
+4. Add secret configuration
+
+   Any usernames and passwords should be added to a `.env` file in the root directory of this project. At the moment these environment variables are used solely for logging in to the UCSD VPN.
+   ```
+   # In the .env file:
+   VPN_USERNAME=<your UCSD username>
+   VPN_USERGROUP=<the 'group' to use for the VPN -- probably "2-Step Secured - allthruucsd">
+   VPN_PASSWORD=<your UCSD password>
+   ```
+
+5. Run the tool, deploying all containers specified in the Compose file
    ```
    make run
    ```
 
-5. Interrupt the tool
+6. Interrupt the tool
    
-   The first step of gracefully stopping this tool is to send an interrupt signal to the daemon.
+   To gracefully stop this tool, you must send an interrupt signal to the daemon. You can send this from a new terminal window or tab. Failure to send the interrupt will result in the data for that session not being collected.
    ```
-   docker kill -s SIGINT netem_daemon_1
+   make interrupt
    ```
 
    The daemon will catch the interrupt and tear down all containers. Collected data will be present in `data/`.
 
-6. Finish with the tool completely
+7. Finish with the tool completely
    
    Once you are completely done with the tool, you can ensure all aspects of the tool are stopped.
    ```

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -41,9 +41,10 @@ RUN curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
 RUN pip install \
     selenium
 
-#* VPN-RELATED SOFTWARE
+# Dependencies for connecting to a VPN
 RUN apt-get install -y openconnect && \
-    curl -O https://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script
+    curl -O https://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script && \
+    chmod +x ./vpnc-script
 
 # ADD scripts/init/client.sh /
 # RUN chmod +x /client.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       - ../scripts/:/scripts/
       - ../network-stats/:/network-stats/
       - ../data/:/data/
+    env_file:
+      - ../.env
     labels:
       com.netem.type: client
       com.netem.behavior: ping

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -117,9 +117,10 @@ def teardown_router(router):
 def setup_client(client):
     """
     Callback to docker startup event listener. Runs, in order:
-    1. Network emulation
-    2. Behavior launching
-    3. Network-stats collection
+    1. Connect to router
+    2. Connect to vpn
+    3. Behavior launching
+    4. Network-stats collection
     """
 
     logging.info(f"[+] Setting up client `{client.name}`")
@@ -136,6 +137,33 @@ def setup_client(client):
     )
 
     logging.info(f'Client `{client.name}` connected to internal router.')
+
+    ## Connect to vpn
+
+    # The username, group, and password for our vpn are all loaded into the
+    # client's environment variables. See `/.env`
+    # We can use these variables to log into the vpn without the need for
+    # interactivity!
+    #
+    # We don't want to continue with behavior launching and data collection
+    # until we've successfully connected to the vpn, so we'll run openconnect
+    # in a --background mode and we can wait for the foreground process to exit.
+    #
+    # Determining whether it exited due to a success or an error is a TODO item.
+    exitcode, output = client.exec_run([
+        'sh', '-c',
+        'echo "$VPN_PASSWORD" \
+        | openconnect --script ./vpnc-script --disable-ipv6 \
+        -u "$VPN_USERNAME" --authgroup="$VPN_USERGROUP" --passwd-on-stdin \
+        --non-inter --background \
+        vpn.ucsd.edu \
+        && exit 0'
+    ])
+
+    if exitcode != 0 :
+        raise Exception(f'{client.name} did not connect to the VPN!')
+
+    logging.info(f'Client `{client.name}` connected to VPN.')
 
     ## Behavior launching
 
@@ -298,7 +326,11 @@ this tool. Failure to do so will result in data loss.\n\
 
 if __name__ == "__main__":
 
-    routers, clients = listen_for_container_startup(timeout=8)
+    # Timeout needs to be sufficiently large to allow for all containers to be
+    # connected to VPN, sequentially.
+    #
+    # TODO: Make event listener for startup non-blocking.
+    routers, clients = listen_for_container_startup(timeout=60)
 
     listen_for_interrupt(handler=lambda: handle_interrupt(routers, clients))
     

--- a/scripts/daemon.py
+++ b/scripts/daemon.py
@@ -148,8 +148,6 @@ def setup_client(client):
     # We don't want to continue with behavior launching and data collection
     # until we've successfully connected to the vpn, so we'll run openconnect
     # in a --background mode and we can wait for the foreground process to exit.
-    #
-    # Determining whether it exited due to a success or an error is a TODO item.
     exitcode, output = client.exec_run([
         'sh', '-c',
         'echo "$VPN_PASSWORD" \
@@ -280,9 +278,8 @@ def listen_for_container_startup(timeout=15):
     except TimeoutError:
         logging.info('Timeout seen.')
 
-    finally:
-        logging.info('No longer listening for docker events.')
-        return routers, clients
+    logging.info('No longer listening for docker events.')
+    return routers, clients
 
 def handle_interrupt(routers, clients):
 


### PR DESCRIPTION
After creating a `.env` file with variables for the vpn username, group, and password, the clients will now automatically log in to the UCSD vpn during the setup stage. For each container you still need to accept the Duo two-factor authentication from your phone.

Test on Linux and Windows.